### PR TITLE
fix: add Bearer token fallback for iOS Safari cross-domain cookie blo…

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -68,8 +68,9 @@ export class AuthController {
     const { access_token, refresh_token, user } =
       await this.authService.register(dto.email, dto.password);
     this.setAuthCookies(res, access_token, refresh_token);
-    // Return only non-sensitive user data — never return the raw token in the body
-    return { user };
+    // Also return the token in the body so clients where cross-domain cookies are
+    // blocked (iOS Safari ITP) can fall back to Authorization: Bearer header auth.
+    return { user, access_token };
   }
 
   // Tighter limit on login to slow credential-stuffing attacks
@@ -97,7 +98,7 @@ export class AuthController {
       dto.password,
     );
     this.setAuthCookies(res, access_token, refresh_token);
-    return { user };
+    return { user, access_token };
   }
 
   @Post('refresh')

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -1,7 +1,10 @@
 /**
  * All requests use `credentials: 'include'` so the browser automatically
- * attaches the httpOnly access_token cookie. No token is ever read from or
- * written to JavaScript-accessible storage.
+ * attaches the httpOnly access_token cookie (preferred, XSS-safe path).
+ *
+ * As a fallback for browsers that block cross-domain cookies (iOS Safari ITP),
+ * the access token returned by login/register is also stored in sessionStorage
+ * and sent as an Authorization: Bearer header on every request.
  *
  * On a 401 the client silently calls POST /auth/refresh to get a new
  * access token (the refresh token cookie is sent automatically) and retries
@@ -9,16 +12,27 @@
  * to /login.
  */
 import { Task, TaskFormData, AuthResponse } from './types';
-import { clearUser } from './auth';
+import { clearUser, getToken, setToken } from './auth';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
+// Returns Authorization: Bearer header when a token is stored in sessionStorage.
+// This is the fallback for mobile Safari where cross-domain cookies are blocked.
+function bearerHeaders(): Record<string, string> {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 // ── Core fetch wrapper with silent token refresh ─────────────────────────────
 
 async function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
-  const opts: RequestInit = { ...options, credentials: 'include' };
+  const opts: RequestInit = {
+    ...options,
+    credentials: 'include',
+    headers: { ...bearerHeaders(), ...(options.headers as Record<string, string> ?? {}) },
+  };
   let res = await fetch(url, opts);
 
   if (res.status === 401) {
@@ -55,7 +69,10 @@ export async function loginUser(email: string, password: string): Promise<AuthRe
     const msg = body.message;
     throw new Error(Array.isArray(msg) ? msg.join(', ') : (msg ?? 'Invalid credentials'));
   }
-  return res.json();
+  const data: AuthResponse = await res.json();
+  // Save token as Bearer fallback for browsers that block cross-domain cookies.
+  if (data.access_token) setToken(data.access_token);
+  return data;
 }
 
 export async function registerUser(email: string, password: string): Promise<AuthResponse> {
@@ -70,7 +87,9 @@ export async function registerUser(email: string, password: string): Promise<Aut
     const msg = body.message;
     throw new Error(Array.isArray(msg) ? msg.join(', ') : (msg ?? 'Registration failed'));
   }
-  return res.json();
+  const data: AuthResponse = await res.json();
+  if (data.access_token) setToken(data.access_token);
+  return data;
 }
 
 export async function logoutUser(): Promise<void> {
@@ -81,7 +100,10 @@ export async function logoutUser(): Promise<void> {
 }
 
 export async function getMe(): Promise<{ id: number; email: string }> {
-  const res = await fetch(`${API_BASE}/auth/me`, { credentials: 'include' });
+  const res = await fetch(`${API_BASE}/auth/me`, {
+    credentials: 'include',
+    headers: bearerHeaders(),
+  });
   if (!res.ok) throw new Error('Not authenticated');
   return res.json();
 }

--- a/frontend/app/lib/auth.ts
+++ b/frontend/app/lib/auth.ts
@@ -1,13 +1,13 @@
 /**
- * Stores only non-sensitive display data (user id + email) in sessionStorage.
- * JWTs are stored exclusively in httpOnly cookies set by the backend —
- * they are never accessible from JavaScript, which eliminates the XSS
- * attack vector that would exist if tokens were stored in localStorage.
+ * Stores non-sensitive display data (user id + email) and, as a fallback for
+ * browsers that block cross-domain cookies (iOS Safari ITP), the access token
+ * itself. Both live in sessionStorage so they are cleared when the tab closes.
  *
- * sessionStorage is used instead of localStorage so data is cleared
- * automatically when the browser tab is closed.
+ * Preferred path: httpOnly cookie set by the backend (never readable from JS).
+ * Fallback path:  sessionStorage token sent as Authorization: Bearer header.
  */
 const USER_KEY = 'tm_user';
+const TOKEN_KEY = 'tm_access_token';
 
 export interface AuthUser {
   id: number;
@@ -30,4 +30,18 @@ export function setUser(user: AuthUser): void {
 
 export function clearUser(): void {
   sessionStorage.removeItem(USER_KEY);
+  sessionStorage.removeItem(TOKEN_KEY);
+}
+
+export function getToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return sessionStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  sessionStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+  sessionStorage.removeItem(TOKEN_KEY);
 }

--- a/frontend/app/lib/types.ts
+++ b/frontend/app/lib/types.ts
@@ -22,8 +22,10 @@ export interface TaskFormData {
   category?: string;
 }
 
-// access_token is no longer returned in the body — it is set as an httpOnly cookie
-// by the backend. Only non-sensitive user info is returned to the client.
+// The backend sets access_token as an httpOnly cookie (preferred path, XSS-safe).
+// It also returns the token in the body so that clients where cross-domain cookies
+// are blocked (iOS Safari ITP) can fall back to Authorization: Bearer header auth.
 export interface AuthResponse {
   user: { id: number; email: string };
+  access_token: string;
 }


### PR DESCRIPTION
## What does this PR do?
Fixes an infinite redirect loop on iOS Safari after login/register.

## Root cause
iOS Safari ITP (Intelligent Tracking Prevention) blocks cross-domain 
Set-Cookie headers. Since frontend (vercel.app) and backend (railway.app) 
are on different domains, Safari never stores the httpOnly cookie — 
causing every authenticated request to return 401 and redirect to /login.

## How it was fixed
Added a dual-path authentication strategy:
- Desktop browsers: httpOnly cookies work as before ✅
- Mobile Safari: access_token returned in response body, stored in 
  sessionStorage, sent as Authorization: Bearer header ✅

The NestJS JWT strategy already supported Bearer header extraction,
so no backend changes were needed for the auth path.

## Files changed
- backend/src/auth/auth.controller.ts — return access_token in body
- frontend/app/lib/types.ts — AuthResponse includes access_token
- frontend/app/lib/auth.ts — sessionStorage token helpers
- frontend/app/lib/api.ts — bearerHeaders() injected in all requests

## How to test
1. Open https://task-manager-zeta-sepia.vercel.app on iPhone/Safari
2. Register or login
3. Should redirect to dashboard instead of looping back to login

## Checklist
- [x] `npm run lint:ci` passes
- [x] `npm run test` passes
- [x] No secrets in diff
- [x] Tested on mobile Safari