### PR TITLE
fix: use multi-stage Dockerfile to fix nest build not found

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,12 +1,24 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
 FROM node:20-alpine
 
 WORKDIR /app
 
 COPY package*.json ./
+
 RUN npm ci --only=production
 
-COPY . .
-RUN npm run build
+COPY --from=builder /app/dist ./dist
 
 EXPOSE 3001
 


### PR DESCRIPTION
## What does this PR do?
Adds Docker support for local development using multi-stage build.

## Why multi-stage build?
Stage 1 (builder): installs ALL dependencies including devDependencies,
runs nest build to compile TypeScript.
Stage 2 (final): installs only production dependencies, copies compiled
dist/ — smaller and faster image.

## How to run locally
docker-compose up --build

This starts both backend (port 3001) and frontend (port 3000) in isolated
containers — same environment as production.

## Checklist
- [x] docker-compose up --build works locally
- [x] Backend NestJS starts successfully in container
- [x] Frontend Next.js starts successfully in container
- [x] No secrets in Dockerfile