### PR TITLE
fix: handle null and empty string dueDate in UpdateTaskDto validation

### DIFF
--- a/backend/src/tasks/dto/update-task.dto.ts
+++ b/backend/src/tasks/dto/update-task.dto.ts
@@ -55,12 +55,14 @@ export class UpdateTaskDto {
 
   @ApiProperty({
     example: '2026-05-01',
-    description: 'Updated due date (ISO 8601)',
+    description: 'Updated due date (ISO 8601), or null to clear',
     required: false,
+    nullable: true,
   })
+  @Transform(({ value }) => (value === '' ? undefined : value))
   @IsDateString({}, { message: 'dueDate must be a valid ISO 8601 date string' })
   @IsOptional()
-  dueDate?: string;
+  dueDate?: string | null;
 
   @ApiProperty({
     example: 'Work',

--- a/backend/src/tasks/dto/update-task.dto.ts
+++ b/backend/src/tasks/dto/update-task.dto.ts
@@ -59,7 +59,9 @@ export class UpdateTaskDto {
     required: false,
     nullable: true,
   })
-  @Transform(({ value }) => (value === '' ? undefined : value))
+  @Transform(({ value }): string | null | undefined =>
+    value === '' ? undefined : (value as string | null | undefined),
+  )
   @IsDateString({}, { message: 'dueDate must be a valid ISO 8601 date string' })
   @IsOptional()
   dueDate?: string | null;


### PR DESCRIPTION
## What does this PR do?
Fixes a 400 Bad Request error when updating a task in production.

## Root cause
UpdateTaskDto was rejecting requests where dueDate was sent as 
empty string "" — @IsDateString() validation fails on empty string.
Frontend was sending "" instead of null/undefined when dueDate is empty.

## Fix
- UpdateTaskDto: transform empty string dueDate to undefined/null
- All fields verified as @IsOptional()
- Frontend: send null instead of "" for empty dueDate

## How to test
1. Go to task-manager-zeta-sepia.vercel.app
2. Edit any existing task
3. Save without changing dueDate
4. Should succeed without 400 error

## Checklist
- [x] npm run test passes
- [x] npm run lint:ci passes
- [x] Tested in production
- [x] No secrets in diff